### PR TITLE
Fixed: When setting a new configuration and there are several 'last requ...

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.6.1 / 28 Apr 2015
+* Fixed: When setting a new configuration and there are several 'last requests' for such a configuration, only one
+  'last request' is removed.
+
 ## v0.6.0 / 13 Feb 2015
 * Added support to use the mock programmatically. A mock instance can created using the `createServer` function
   and there are methods to `start` and `stop` the Mock.

--- a/lib/server/middlewares.js
+++ b/lib/server/middlewares.js
@@ -124,7 +124,9 @@ function _buildRequestObject(req, config, cb) {
         try {
           // Try to parse the body as an XML document
           requestObj.bodyJson = xml2json.toJson(requestObj.body, {object: true, coerce: false, sanitize: false});
-        } catch (err) {}
+        } catch (err) {
+          // The body cannot be parsed as JSON nor XML
+        }
       }
     } else {
       requestObj.body = bodyBuffer.toString('base64');
@@ -321,7 +323,10 @@ module.exports = function middlewares(context) {
               return next(new Error('Database error [' + err + ']'));
             }
             // Creating a config implies deleting any related last request
-            context.lastRequests.remove({method: config.method, path: config.path}, {}, function(err, numRemoved) {
+            context.lastRequests.remove(
+                {method: config.method, path: config.path},
+                {multi: true},
+                function(err, numRemoved) {
               if (err) {
                 res.statusCode = 500;
                 return next(new Error('Database error [' + err + ']'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tartare-mock",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A handy server to mock any HTTP behaviour",
   "license": "Apache-2.0",
   "author": "Jose Antonio Rodríguez Fernández <joseantonio.rodriguezfernandez@telefonica.com>",


### PR DESCRIPTION
...ests' for such a configuration, only one 'last request' is removed.
